### PR TITLE
Add StickyWorkerPool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/igmagollo/go-sticky-worker-pool
+
+go 1.22.4

--- a/sticky-worker-pool.go
+++ b/sticky-worker-pool.go
@@ -1,0 +1,200 @@
+package gostickyworkerpool
+
+import (
+	"context"
+	"errors"
+	"hash"
+	"hash/fnv"
+	"sync"
+	"time"
+)
+
+var (
+	ErrStopTimeout       = errors.New("stop timeout")
+	ErrWorkerPoolStopped = errors.New("worker pool has stopped")
+)
+
+// This worker pool uses a hash function to stick keys with workers in order to
+// provide a first-in-first-out behaviour among the workloads with the same key.
+// There is no guarantee of ordering between diferent keys.
+type StickyWorkerPool struct {
+	config      *stickyWorkerPoolConfig
+	workFn      WorkFn
+	workloadChs []chan workload
+	cancel      context.CancelFunc
+	wg          sync.WaitGroup
+	hasher      hash.Hash32
+	stopped     chan struct{}
+}
+
+// WorkFn is the function responsible for handling workloads.
+// It will receive the context, key and args passed to Send function
+// The error will be send to the error channel returned from Send function
+type WorkFn func(ctx context.Context, key string, args any) error
+
+// stickyWorkerPoolConfig carry the configuration of the worker pool
+type stickyWorkerPoolConfig struct {
+	// concurrency measns how many go routines will be running at the same time
+	// Default: 10
+	concurrency uint
+
+	// channelsBufferSize is the size of each channel
+	// Each go routine has its channel to receive workloads and this configuration
+	// impacts in how many workloads it can buffer before the channel blocks
+	// Default: 10
+	channelsBufferSize uint
+
+	// When stopping, the worker pool will stop accepting workloads, and then
+	// it will wait until either all buffered workload is finished or it reaches
+	// timeout.
+	// If zero, timeout is ignored
+	// Default: 10 seconds
+	stopTimeout time.Duration
+}
+
+type stickyWorkerPoolOption func(config *stickyWorkerPoolConfig)
+
+type workload struct {
+	ctx   context.Context
+	key   string
+	args  any
+	errCh chan<- error
+}
+
+// Creates a new StickyWorkerPool
+func NewStickyWorkerPool(workFn WorkFn, options ...stickyWorkerPoolOption) *StickyWorkerPool {
+	config := stickyWorkerPoolConfigDefaults()
+	for _, option := range options {
+		option(config)
+	}
+
+	workerPool := &StickyWorkerPool{
+		config:  config,
+		workFn:  workFn,
+		wg:      sync.WaitGroup{},
+		hasher:  fnv.New32a(),
+		stopped: make(chan struct{}),
+	}
+
+	workerPool.workloadChs = make([]chan workload, 0, workerPool.config.concurrency)
+	for i := uint(0); i < workerPool.config.concurrency; i++ {
+		ch := make(chan workload, workerPool.config.channelsBufferSize)
+		workerPool.workloadChs = append(workerPool.workloadChs, ch)
+	}
+
+	return workerPool
+}
+
+// Start starts the workers of the pool
+// It creates starts <concurrency> go routines a.k.a. workers
+func (s *StickyWorkerPool) Start(ctx context.Context) {
+	ctx, s.cancel = context.WithCancel(ctx)
+
+	for i := uint(0); i < s.config.concurrency; i++ {
+		go s.worker(ctx, s.workloadChs[i])
+	}
+}
+
+// This is the worker loop
+// It basically runs WorkerFn for each workload sent and redirect the resulting
+// error to the error channel of that workload
+func (s *StickyWorkerPool) worker(ctx context.Context, workloadsCh <-chan workload) {
+	for work := range workloadsCh {
+		select {
+		case <-ctx.Done():
+			work.errCh <- ctx.Err()
+			close(work.errCh)
+		default:
+			err := s.workFn(work.ctx, work.key, work.args)
+			work.errCh <- err
+			close(work.errCh)
+			s.wg.Done()
+		}
+	}
+}
+
+// Stop stops the worker
+// It prevents worker to receive new workloads returning error and
+// await for the workloads flush or timeout
+func (s *StickyWorkerPool) Stop() error {
+	close(s.stopped)
+	defer s.cancel()
+	for _, ch := range s.workloadChs {
+		close(ch)
+	}
+
+	if s.config.stopTimeout == 0 {
+		s.wg.Wait()
+		return nil
+	}
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		s.wg.Wait()
+	}()
+	select {
+	case <-c:
+		return nil
+	case <-time.After(s.config.stopTimeout):
+		return ErrStopTimeout
+	}
+}
+
+func (s *StickyWorkerPool) Send(ctx context.Context, key string, args any) (<-chan error, error) {
+	select {
+	case <-s.stopped:
+		return nil, ErrWorkerPoolStopped
+	default:
+	}
+
+	errCh := make(chan error, 1)
+	s.wg.Add(1)
+	s.chanOf(key) <- workload{
+		ctx:   ctx,
+		key:   key,
+		args:  args,
+		errCh: errCh,
+	}
+	return errCh, nil
+}
+
+func (s *StickyWorkerPool) hash(key string) uint {
+	s.hasher.Reset()
+	s.hasher.Write([]byte(key))
+	return uint(s.hasher.Sum32())
+}
+
+func (s *StickyWorkerPool) chanOf(key string) chan<- workload {
+	index := s.hash(key) % uint(len(s.workloadChs))
+	return s.workloadChs[index]
+}
+
+func stickyWorkerPoolConfigDefaults() *stickyWorkerPoolConfig {
+	return &stickyWorkerPoolConfig{
+		concurrency:        10,
+		channelsBufferSize: 10,
+		stopTimeout:        time.Second * 10,
+	}
+}
+
+// Set Concurrency of the worker pool config
+func WithConcurrency(concurrency uint) stickyWorkerPoolOption {
+	return func(config *stickyWorkerPoolConfig) {
+		config.concurrency = concurrency
+	}
+}
+
+// Set ChannelsBufferSize of the worker pool config
+func WithChannelsBufferSize(channelsBufferSize uint) stickyWorkerPoolOption {
+	return func(config *stickyWorkerPoolConfig) {
+		config.channelsBufferSize = channelsBufferSize
+	}
+}
+
+// Set Stop timeout of the worker pool config
+func WithStopTimeout(timeout time.Duration) stickyWorkerPoolOption {
+	return func(config *stickyWorkerPoolConfig) {
+		config.stopTimeout = timeout
+	}
+}

--- a/sticky-worker-pool_test.go
+++ b/sticky-worker-pool_test.go
@@ -286,6 +286,8 @@ func TestStickyWorkerPool_Send(t *testing.T) {
 		}
 
 		// Assert
-		sut.Stop()
+		if err := sut.Stop(); err != nil {
+			t.Errorf("sut.Stop() error: %v", err)
+		}
 	})
 }

--- a/sticky-worker-pool_test.go
+++ b/sticky-worker-pool_test.go
@@ -1,0 +1,291 @@
+package gostickyworkerpool
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewStickyWorkerPool(t *testing.T) {
+	t.Parallel()
+	for _, tt := range newStickyWorkerPoolTable {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			got := NewStickyWorkerPool(tt.workFn, tt.options...)
+
+			// Assert
+			if got.config.concurrency != tt.expectedConcurrency {
+				t.Errorf("config.concurrency: expected %d, got %d", tt.expectedConcurrency, got.config.concurrency)
+			}
+			if got.config.channelsBufferSize != tt.expectedChannelsBufferSize {
+				t.Errorf("config.channelsBufferSize: expected %d, got %d", tt.expectedChannelsBufferSize, got.config.channelsBufferSize)
+			}
+			if got.config.stopTimeout != tt.expectedStopTimeout {
+				t.Errorf("config.stopTimeout: expected %d, got %d", tt.expectedConcurrency, got.config.concurrency)
+			}
+			if got.workFn == nil {
+				t.Errorf("workFn: expected not nil, got nil")
+			}
+			if uint(len(got.workloadChs)) != tt.expectedConcurrency {
+				t.Errorf("len(workloadChs): expected %d, got %d", tt.expectedConcurrency, len(got.workloadChs))
+			}
+			for i, ch := range got.workloadChs {
+				if cap(ch) != int(tt.expectedChannelsBufferSize) {
+					t.Errorf("cap(workloadChs[%d]): expected %d, got %d", i, tt.expectedChannelsBufferSize, cap(ch))
+				}
+			}
+
+		})
+	}
+}
+
+var newStickyWorkerPoolTable = []struct {
+	name    string
+	workFn  WorkFn
+	options []stickyWorkerPoolOption
+
+	expectedConcurrency        uint
+	expectedChannelsBufferSize uint
+	expectedStopTimeout        time.Duration
+}{
+	{
+		name:    "should create a work pool with defaults",
+		workFn:  func(ctx context.Context, key string, args any) error { return nil },
+		options: []stickyWorkerPoolOption{},
+
+		expectedConcurrency:        10,
+		expectedChannelsBufferSize: 10,
+		expectedStopTimeout:        10 * time.Second,
+	},
+	{
+		name:    "should create a work pool with 20 concurrency",
+		workFn:  func(ctx context.Context, key string, args any) error { return nil },
+		options: []stickyWorkerPoolOption{WithConcurrency(20)},
+
+		expectedConcurrency:        20,
+		expectedChannelsBufferSize: 10,
+		expectedStopTimeout:        10 * time.Second,
+	},
+	{
+		name:    "should create a work pool with 20 ChannelsBufferSize",
+		workFn:  func(ctx context.Context, key string, args any) error { return nil },
+		options: []stickyWorkerPoolOption{WithChannelsBufferSize(20)},
+
+		expectedConcurrency:        10,
+		expectedChannelsBufferSize: 20,
+		expectedStopTimeout:        10 * time.Second,
+	},
+	{
+		name:    "should create a work pool with 20 seconds of timeout",
+		workFn:  func(ctx context.Context, key string, args any) error { return nil },
+		options: []stickyWorkerPoolOption{WithStopTimeout(20 * time.Second)},
+
+		expectedConcurrency:        10,
+		expectedChannelsBufferSize: 10,
+		expectedStopTimeout:        20 * time.Second,
+	},
+}
+
+func TestStickyWorkerPool_Start(t *testing.T) {
+	t.Parallel()
+	for _, tt := range StickyWorkerPool_StartTable {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sut := NewStickyWorkerPool(tt.workFn)
+
+			// Act
+			sut.Start(context.Background())
+			sut.wg.Add(int(sut.config.concurrency))
+			errChs := make([]chan error, 0, sut.config.concurrency)
+			for i := uint(0); i < sut.config.concurrency; i++ {
+				errCh := make(chan error, 1)
+				sut.workloadChs[i] <- workload{
+					ctx:   context.Background(),
+					key:   "",
+					args:  i,
+					errCh: errCh,
+				}
+				errChs = append(errChs, errCh)
+			}
+
+			// Assert
+			for _, errCh := range errChs {
+				select {
+				case <-errCh:
+				case <-time.After(time.Millisecond):
+				}
+			}
+		})
+	}
+}
+
+var StickyWorkerPool_StartTable = []struct {
+	name    string
+	workFn  WorkFn
+	options []stickyWorkerPoolOption
+}{
+	{
+		name:    "should start workers for default concurrency",
+		workFn:  func(ctx context.Context, key string, args any) error { return nil },
+		options: []stickyWorkerPoolOption{},
+	},
+	{
+		name:    "should start workers for 20 concurrency",
+		workFn:  func(ctx context.Context, key string, args any) error { return nil },
+		options: []stickyWorkerPoolOption{WithConcurrency(20)},
+	},
+}
+
+func TestStickyWorkerPool_Stop(t *testing.T) {
+	t.Parallel()
+	for _, tt := range StickyWorkerPool_StopTable {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sut := NewStickyWorkerPool(tt.workFn)
+
+			// Act
+			sut.Start(context.Background())
+			sut.wg.Add(int(sut.config.concurrency))
+			errChs := make([]chan error, 0, sut.config.concurrency)
+			for i := uint(0); i < sut.config.concurrency; i++ {
+				errCh := make(chan error, 1)
+				sut.workloadChs[i] <- workload{
+					ctx:   context.Background(),
+					key:   "",
+					args:  i,
+					errCh: errCh,
+				}
+				errChs = append(errChs, errCh)
+			}
+			err := sut.Stop()
+
+			// Assert
+			if err != nil {
+				t.Errorf("expect error to not occur, got %s", err.Error())
+			}
+
+			for _, errCh := range errChs {
+				select {
+				case <-errCh:
+				default:
+					t.Errorf("expect channel to receive nil, got blocked channel")
+				}
+			}
+		})
+	}
+
+	t.Run("should return timout err", func(t *testing.T) {
+		t.Parallel()
+		// Arrange
+		sut := NewStickyWorkerPool(func(ctx context.Context, key string, args any) error {
+			time.Sleep(1 * time.Second)
+			return nil
+		}, WithStopTimeout(1*time.Nanosecond))
+
+		// Act
+		sut.wg.Add(int(sut.config.concurrency))
+		for i := uint(0); i < sut.config.concurrency; i++ {
+			sut.workloadChs[i] <- workload{
+				ctx:   context.Background(),
+				key:   "",
+				args:  i,
+				errCh: make(chan error, 1),
+			}
+		}
+		sut.Start(context.Background())
+		err := sut.Stop()
+
+		// Assert
+		if !errors.Is(err, ErrStopTimeout) {
+			t.Errorf("expect error to be %s, got %s", ErrStopTimeout.Error(), err.Error())
+		}
+	})
+}
+
+var StickyWorkerPool_StopTable = []struct {
+	name    string
+	workFn  WorkFn
+	options []stickyWorkerPoolOption
+}{
+	{
+		name: "should start workers for default concurrency",
+		workFn: func(ctx context.Context, key string, args any) error {
+			return nil
+		},
+		options: []stickyWorkerPoolOption{},
+	},
+	{
+		name: "should start workers for 20 concurrency",
+		workFn: func(ctx context.Context, key string, args any) error {
+			return nil
+		},
+		options: []stickyWorkerPoolOption{WithConcurrency(20)},
+	},
+	{
+		name: "should start workers for 100 concurrency",
+		workFn: func(ctx context.Context, key string, args any) error {
+			return nil
+		},
+		options: []stickyWorkerPoolOption{WithConcurrency(100)},
+	},
+}
+
+func TestStickyWorkerPool_Send(t *testing.T) {
+	t.Parallel()
+	t.Run("should return timout err", func(t *testing.T) {
+		t.Parallel()
+		// Arrange
+		entries := map[string]int{
+			"1":  0,
+			"2":  0,
+			"3":  0,
+			"4":  0,
+			"5":  0,
+			"6":  0,
+			"7":  0,
+			"8":  0,
+			"9":  0,
+			"10": 0,
+		}
+		mutex := sync.RWMutex{}
+		sut := NewStickyWorkerPool(func(ctx context.Context, key string, args any) error {
+			// simulate some IO
+			time.Sleep(time.Microsecond * time.Duration(rand.Intn(100)))
+
+			newVal := args.(int)
+			mutex.RLock()
+			curr := entries[key]
+			mutex.RUnlock()
+			if newVal != curr+1 {
+				t.Errorf("entry[%s]: expect %d, got %d", key, curr+1, newVal)
+			}
+			mutex.Lock()
+			entries[key] = newVal
+			mutex.Unlock()
+
+			return nil
+		})
+		sut.Start(context.Background())
+
+		// Act
+		for i := 0; i < 10000; i++ {
+			key := strconv.Itoa(i % 10)
+			args := i/10 + 1
+
+			_, err := sut.Send(context.Background(), key, args)
+			if err != nil {
+				t.Errorf("expect nil error, got '%s'", err.Error())
+			}
+		}
+
+		// Assert
+		sut.Stop()
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a sticky worker pool to ensure tasks with the same key are processed in a first-in-first-out order.

- **Tests**
  - Added comprehensive test cases for the sticky worker pool, including creation, configuration, start/stop functionalities, and task execution verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->